### PR TITLE
Adding DeepIntersection in the collection

### DIFF
--- a/types/collections.d.ts
+++ b/types/collections.d.ts
@@ -109,3 +109,29 @@ export type Paths< T, D extends number = 5 > = [ D ] extends [ never ] ? never :
 export type PathValue< T, P extends string > = P extends `${ infer K }.${ infer Rest }`
     ? K extends keyof T ? PathValue< T[ K ], Rest > : never
     : P extends keyof T ? T[ P ] : never;
+
+
+/**
+ * Deep Intersection (recursive)
+ * @example
+ * type Nested = { level_1: { level_2: { } } };
+ * type MetaData = { metadata?: string };
+ * type DeepIntersected = DeepIntersection<Nested, MetaData>;
+ * // { level_1: { level_2: { metadata: '' } } }
+}
+ * @remarks
+ * In case of property conflict, the Target type(T) will not get its properties overwritten by the aDditionnal type(D)
+ */
+export type DeepIntersection< T, D > = {
+  [ P in keyof T ]: T[ P ] extends Array< infer U >
+        ? DeepIntersection< U, D>[]
+        : T[ P ] extends ReadonlyArray< infer U >
+        ? ReadonlyArray< DeepIntersection< U, D > >
+        : T[ P ] extends object
+            ? DeepIntersection< T[ P ], D >
+            : T[ P ];
+} & {
+  [ P in keyof D ]: P extends keyof T ? 
+    never : 
+    D[ P ]
+};


### PR DESCRIPTION
Very Similar to what deep merge is, however the right hand doesn't overwrite.
I actually forgot about deep merge and only saw it when I was nearly finishing that.

I believe that DeepMerge would be better into collection rather than Util.
Merging is more a runtime word, where as Intersection is more type word.

Side note I haven't extensively tested that type, I just needed it for one of my works and it worked good enough so I posted it here.